### PR TITLE
Add link to Terra language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terra mode
 
-An Emacs major mode for Terra based on [lua-mode](https://github.com/immerrr/lua-mode).
+An Emacs major mode for [Terra](https://terralang.org/) based on [lua-mode](https://github.com/immerrr/lua-mode).
 
 # Lua mode
 


### PR DESCRIPTION
It's actually difficult to know what Terra is just by searching. I intially thought this was likely something to do with Terraform. I've made the name in the description a link to that project so this projects description is clearer.